### PR TITLE
Last.fm api fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,17 +69,31 @@
           apiKey = newApiKey
         }
 
-        let apiUrl = `https://ws.audioscrobbler.com/2.0/?method=track.search&track=${search}&api_key=${apiKey}&limit=10000&format=json`;
+  let array1 = [];
 
-        let response = await fetch(apiUrl);
-        let data = await response.json();
-
-        if (data.message != null) {
-          searching.remove();
-          alert(data.message);
-        }
-          
-        let array1 = data.results.trackmatches.track;
+  for (let page = 1; page <= 10; page++) {
+    let apiUrl = `https://ws.audioscrobbler.com/2.0/?method=track.search&track=${search}&api_key=${apiKey}&limit=1000&page=${page}&format=json`;
+  
+    try {
+      let response = await fetch(apiUrl);
+      let data = await response.json();
+  
+      if (data.message != null) {
+        searching.remove();
+        alert(data.message);
+        break; 
+      }
+  
+      if (!data.results?.trackmatches?.track?.length) {
+        break;
+      }
+  
+      array1 = array1.concat(data.results.trackmatches.track);
+    } catch (error) {
+      console.error("Error:", page, error);
+      break; 
+    }
+  }
 
         searching.remove();
 


### PR DESCRIPTION
Last.fm recently made changes to the api.
It is not possible anymore to get 10k results instead they reduced it to a maximum of 1k. To still get all of the 10k results it is possible to use the page parameter.